### PR TITLE
ignore the specific warning about string buffer overflow

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -48,6 +48,9 @@ cc_library(
     hdrs = [
         "//:public_headers",
     ],
+    copts = [
+        "-Wno-stringop-overflow",
+    ],
     linkopts = select({
         # TODO: Bazel uses `clang` instead of `clang++` to link
         # C++ code on BSD. Temporarily adding these linker flags while


### PR DESCRIPTION
Ignore the specific warning that is produced when compiling flatbuffers/flatc as an external dependecy
NOTE::: this compiles without warnings directly in the repo, but warnings show up when using it as an external dependency <shrug>.

warning is for line 621 in `src/reflection.cpp`
`flatbuf.insert(flatbuf.end(), newbuf + sizeof(uoffset_t), newbuf + newlen);`

the warning is a `stringop-overflow` 
gcc manual
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wstringop-overflow

this is adding the specific compiler flag to ignore this for the cc_library `flatbuffers` target

There are other options to target this line specifically.
```
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wstringop-overflow"
    flatbuf.insert(flatbuf.end(), newbuf + sizeof(uoffset_t), newbuf + newlen);
#pragma GCC diagnostic pop
```

-- Test
in AMV repo - add local_override for flatbuffers
`bazel build //...`